### PR TITLE
Install gcc to be able to build ruamel.yaml.clib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash python3-dev gcc libc-dev
 RUN pip install --no-cache-dir pykwalify
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
`ruamel.yaml.clib` failed to build for quite some time. But it seems to have been a non-fatal error in the past.
See https://github.com/AndroidStudyGroup/conferences/runs/5556890896?check_suite_focus=true#step:3:57

Now it's a fatal error.
See https://github.com/AndroidStudyGroup/conferences/runs/5603484251?check_suite_focus=true#step:3:69